### PR TITLE
Fix styling bug

### DIFF
--- a/content/get-started.html
+++ b/content/get-started.html
@@ -27,7 +27,7 @@ title = "title_getstarted"
                 </g>
               </svg>
               <h4>{{% i18n "getstarted_storeiconh" %}}</h4>
-              {{% i18n "getstarted_storeiconp" %}}
+              <p> {{% i18n "getstarted_storeiconp" %}} </p>
             </a>
           </li>
           <li role="presentation" class="col-md-3">
@@ -46,7 +46,7 @@ title = "title_getstarted"
                 </g>
               </svg>
               <h4>{{% i18n "getstarted_farmiconh" %}}</h4>
-              {{% i18n "getstarted_farmiconp" %}}
+              <p> {{% i18n "getstarted_farmiconp" %}} </p>
             </a>
           </li>
           <li role="presentation" class="col-md-3">
@@ -59,7 +59,7 @@ title = "title_getstarted"
                 </g>
               </svg>
               <h4>{{% i18n "getstarted_mineiconh" %}}</h4>
-              {{% i18n "getstarted_mineiconp" %}}
+              <p> {{% i18n "getstarted_mineiconp" %}} </p>
             </a>
           </li>
           <li role="presentation" class="col-md-3">
@@ -75,7 +75,7 @@ title = "title_getstarted"
                 </g>
               </svg>
               <h4>{{% i18n "getstarted_developiconh" %}}</h4>
-              {{% i18n "getstarted_developiconp" %}}
+              <p> {{% i18n "getstarted_developiconp" %}} </p>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
Fix styling bug introduced by 7973eaae9d589150e9ac074b4be2b539270c9cc6

This commit reverts the changes to get-started.html introduced by that commit, and adds spaces around the shortcode, as in bab5dac8990ddda5137d4473d052db460d131ace
See issue #33
