### PR TITLE
Add translation warning bar

### DIFF
--- a/content/about/milestones.html
+++ b/content/about/milestones.html
@@ -1,5 +1,6 @@
 +++
 title = "title_roadmap"
+i18nwarnings = [ "fr", "ru", "zh-hans", "zh-hant" ]
 +++
 <section class="timeline ">
   <div class="container">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,14 @@
   {{ template "_internal/google_analytics_async.html" . }}
 </head>
 <body>
-  <!-- TODO: google analytics -->
+  {{ if .Params.i18nwarnings }}
+    {{ $pagelang := .Lang }}
+    {{ range $lang := .Params.i18nwarnings }}
+      {{ if eq $lang $pagelang }}
+        {{ partial "i18nwarning.html" . }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
   {{ partial "header.html" . }}
   <main>
     {{ block "main" . }}{{ end }}

--- a/layouts/partials/i18nwarning.html
+++ b/layouts/partials/i18nwarning.html
@@ -1,0 +1,3 @@
+<div class="i18n-warning">
+This page is missing translations. If you are able to contribute, please follow the <a href="https://github.com/NebulousLabs/sia.tech/blob/master/TRANSLATION.md">translation guide</a>. Thanks!
+</div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,6 +1,7 @@
 /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
 .video-wrapper { position: relative; padding-bottom: 37.5%; /* 16:10 */ height: 0; }
 .video-wrapper iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
+.i18n-warning { background-color: #ff4d4d; padding: 0.5rem 1rem; }
 html { font-family: sans-serif; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; }
 body { margin: 0; }
 article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary { display: block; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2,6 +2,7 @@
 .video-wrapper { position: relative; padding-bottom: 37.5%; /* 16:10 */ height: 0; }
 .video-wrapper iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
 .i18n-warning { background-color: #ff4d4d; padding: 0.5rem 1rem; }
+.i18n-warning a, .i18n-warning a:hover { color: black; text-decoration: underline; }
 html { font-family: sans-serif; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; }
 body { margin: 0; }
 article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary { display: block; }


### PR DESCRIPTION
and enable it on `/about/milestones/` for fr, ru, zh-hant, zh-hans

This PR is live on https://staging.sia.tech/fr/about/milestones (note the bar may not appear red until the CloudFlare cash is purged)

<img width="1392" alt="screen shot 2016-10-07 at 9 44 17 pm" src="https://cloud.githubusercontent.com/assets/5420909/19209405/9fdd9424-8cd7-11e6-9eaa-bc4f38ed49e4.png">