### PR TITLE
Fix link targets

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -10,7 +10,7 @@ type = "index"
         <h1>{{% i18n "index_bigheader2" %}}</h1>
         <h3>{{% i18n "index_bigheader3" %}}</h3>
         <p>
-          <a class="btn btn-lg" href="get-started" role="button" target="_blank">{{% i18n "index_bigbtn1" %}}</a>
+          <a class="btn btn-lg" href="get-started" role="button">{{% i18n "index_bigbtn1" %}}</a>
         </p>
       </div>
       <div class="col-lg-4 droplet"></div>


### PR DESCRIPTION
AKA don't open the get-started page in a new window when clicking the huge "Get Started" button. I thought there'd by more than just this one link to fix, but I guess not.