### PR TITLE
softlink sia.pdf to /sia.pdf

### DIFF
--- a/static/sia.pdf
+++ b/static/sia.pdf
@@ -1,0 +1,1 @@
+./assets/globals/sia.pdf


### PR DESCRIPTION
This PR creates a softlink to `assets/globals/sia.pdf`, making the whitepaper reachable at `sia.tech/sia.pdf`.