### PR TITLE
remove multilingual symlinks, generate multilingual files using build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project uses [Hugo](https://github.com/spf13/Hugo/) to generate the static 
 ```
 git clone https://github.com/NebulousLabs/sia.tech.git
 cd sia.tech
-hugo
+./build.sh
 ```
 
 Hugo also has a built-in server for testing the site locally.

--- a/build.sh
+++ b/build.sh
@@ -4,10 +4,8 @@ LANGS=( "de" "fr" "ru" "zh-hans" "zh-hant" )
 
 for file in $(find ./content -name '*.html')
 do
-	echo $file
 	for lang in ${LANGS[@]}
 	do
-		echo $lang
 		cp $file ${file%.html}.$lang.html
 	done
 done

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+LANGS=( "de" "fr" "ru" "zh-hans" "zh-hant" )
+
+for file in $(find ./content -name '*.html')
+do
+	echo $file
+	for lang in ${LANGS[@]}
+	do
+		echo $lang
+		cp $file ${file%.html}.$lang.html
+	done
+done
+
+hugo
+

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,11 @@
 
 LANGS=( "de" "fr" "ru" "zh-hans" "zh-hant" )
 
+for oldfile in $(find ./content -name '*.*.html')
+do
+	rm $oldfile
+done
+
 for file in $(find ./content -name '*.html')
 do
 	for lang in ${LANGS[@]}

--- a/content/about/index.de.html
+++ b/content/about/index.de.html
@@ -1,1 +1,0 @@
-index.html

--- a/content/about/index.fr.html
+++ b/content/about/index.fr.html
@@ -1,1 +1,0 @@
-index.html

--- a/content/about/index.ru.html
+++ b/content/about/index.ru.html
@@ -1,1 +1,0 @@
-index.html

--- a/content/about/index.zh-hans.html
+++ b/content/about/index.zh-hans.html
@@ -1,1 +1,0 @@
-index.html

--- a/content/about/index.zh-hant.html
+++ b/content/about/index.zh-hant.html
@@ -1,1 +1,0 @@
-index.html

--- a/content/about/milestones.de.html
+++ b/content/about/milestones.de.html
@@ -1,1 +1,0 @@
-milestones.html

--- a/content/about/milestones.fr.html
+++ b/content/about/milestones.fr.html
@@ -1,1 +1,0 @@
-milestones.html

--- a/content/about/milestones.ru.html
+++ b/content/about/milestones.ru.html
@@ -1,1 +1,0 @@
-milestones.html

--- a/content/about/milestones.zh-hans.html
+++ b/content/about/milestones.zh-hans.html
@@ -1,1 +1,0 @@
-milestones.html

--- a/content/about/milestones.zh-hant.html
+++ b/content/about/milestones.zh-hant.html
@@ -1,1 +1,0 @@
-milestones.html

--- a/content/apps.de.html
+++ b/content/apps.de.html
@@ -1,1 +1,0 @@
-apps.html

--- a/content/apps.fr.html
+++ b/content/apps.fr.html
@@ -1,1 +1,0 @@
-apps.html

--- a/content/apps.ru.html
+++ b/content/apps.ru.html
@@ -1,1 +1,0 @@
-apps.html

--- a/content/apps.zh-hans.html
+++ b/content/apps.zh-hans.html
@@ -1,1 +1,0 @@
-apps.html

--- a/content/apps.zh-hant.html
+++ b/content/apps.zh-hant.html
@@ -1,1 +1,0 @@
-apps.html

--- a/content/faq.de.html
+++ b/content/faq.de.html
@@ -1,1 +1,0 @@
-faq.html

--- a/content/faq.fr.html
+++ b/content/faq.fr.html
@@ -1,1 +1,0 @@
-faq.html

--- a/content/faq.ru.html
+++ b/content/faq.ru.html
@@ -1,1 +1,0 @@
-faq.html

--- a/content/faq.zh-hans.html
+++ b/content/faq.zh-hans.html
@@ -1,1 +1,0 @@
-faq.html

--- a/content/faq.zh-hant.html
+++ b/content/faq.zh-hant.html
@@ -1,1 +1,0 @@
-faq.html

--- a/content/get-siacoin.de.html
+++ b/content/get-siacoin.de.html
@@ -1,1 +1,0 @@
-get-siacoin.html

--- a/content/get-siacoin.fr.html
+++ b/content/get-siacoin.fr.html
@@ -1,1 +1,0 @@
-get-siacoin.html

--- a/content/get-siacoin.ru.html
+++ b/content/get-siacoin.ru.html
@@ -1,1 +1,0 @@
-get-siacoin.html

--- a/content/get-siacoin.zh-hans.html
+++ b/content/get-siacoin.zh-hans.html
@@ -1,1 +1,0 @@
-get-siacoin.html

--- a/content/get-siacoin.zh-hant.html
+++ b/content/get-siacoin.zh-hant.html
@@ -1,1 +1,0 @@
-get-siacoin.html

--- a/content/get-started.de.html
+++ b/content/get-started.de.html
@@ -1,1 +1,0 @@
-get-started.html

--- a/content/get-started.fr.html
+++ b/content/get-started.fr.html
@@ -1,1 +1,0 @@
-get-started.html

--- a/content/get-started.ru.html
+++ b/content/get-started.ru.html
@@ -1,1 +1,0 @@
-get-started.html

--- a/content/get-started.zh-hans.html
+++ b/content/get-started.zh-hans.html
@@ -1,1 +1,0 @@
-get-started.html

--- a/content/get-started.zh-hant.html
+++ b/content/get-started.zh-hant.html
@@ -1,1 +1,0 @@
-get-started.html

--- a/content/index.de.html
+++ b/content/index.de.html
@@ -1,1 +1,0 @@
-index.html

--- a/content/index.fr.html
+++ b/content/index.fr.html
@@ -1,1 +1,0 @@
-index.html

--- a/content/index.ru.html
+++ b/content/index.ru.html
@@ -1,1 +1,0 @@
-index.html

--- a/content/index.zh-hans.html
+++ b/content/index.zh-hans.html
@@ -1,1 +1,0 @@
-index.html

--- a/content/index.zh-hant.html
+++ b/content/index.zh-hant.html
@@ -1,1 +1,0 @@
-index.html


### PR DESCRIPTION
This PR adds a build script which generates the required multilingual files and removes the symlinks used previously, since they are not supported by hugo.