### PR TITLE
Link to i18n get-started page, not English page

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -18,7 +18,7 @@ i18nwarnings = [ "zh-hant", "ru" ]
 				<div class="column is-hidden-mobile"></div>
 				<div class="column is-hidden-mobile"></div>
 				<div class="column">
-					<a href="http://sia.tech/get-started" class="button is-large is-primary is-inverted is-outlined"> {{% i18n "index_getstartedbtn" %}} </a>
+					<a href="get-started" class="button is-large is-primary is-inverted is-outlined"> {{% i18n "index_getstartedbtn" %}} </a>
 				</div>
 				<div class="column">
 					<button class="button is-large is-primary is-inverted is-outlined" id="watchvideobutton"> {{% i18n "index_watchvideobtn" %}} </button>
@@ -167,7 +167,7 @@ i18nwarnings = [ "zh-hant", "ru" ]
 		<div class="columns transform-buttons has-text-centered">
 			<div class="column"></div>
 			<div class="column">
-				<a href="/get-started" class="button is-large is-outlined"> {{% i18n "index_transformcloudgetstarted" %}} </a>
+				<a href="get-started" class="button is-large is-outlined"> {{% i18n "index_transformcloudgetstarted" %}} </a>
 			</div>
 			<div class="column">
 				<a href="mailto:hello@sia.tech" class="button is-large is-outlined"> {{% i18n "index_transformcloudcontact" %}} </a>


### PR DESCRIPTION
Was browsing the homepage in German and noticed this. Simple fix :)

Link to `get-started` instead of `(...)/get-started` to link to the current language's page instead of the English page.