### PR TITLE
Updates to contact button and language

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -133,13 +133,13 @@
   translation: "Sia stores tiny pieces of your files on dozens of nodes across the globe. This eliminates any single point of failure and ensures highest possible uptime, on par with other cloud storage providers."
 
 - id: index_info4_title
-  translation: "Open Source"
+  translation: "Open source"
 
 - id: index_info4_content
   translation: "Sia is completely open source. Over a dozen individuals have contributed to Sia's software, and there is an active community building innovative applications on top of the Sia API."
 
 - id: index_info5_title
-  translation: "Built on blockchain"
+  translation: "Blockchain marketplace"
 
 - id: index_info5_content
   translation: "Using the Sia blockchain, Sia creates a decentralized storage marketplace in which hosts compete for your business – this leads to the lowest possible prices. Renters pay using Siacoin, which can also be mined and traded."

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -59,7 +59,7 @@
         <div class="col-lg-12 questions" class="col-lg-2 col-sm-4">
           <ul>
             <li><span class="list-header">{{ i18n "footer_questions" }}</span></li>
-            <li><a href="mailto:hello@sia.tech" target="_blank" class="email btn btn-reverse"style="margin-top:9px;">{{ i18n "footer_contact" }}</a></li>
+            <li><a href="javascript:groove.widget('open')" class="email btn btn-reverse"style="margin-top:9px;">{{ i18n "footer_contact" }}</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Contact button opens Groove support widget instead of an email. This way users can try to help themselves before emailing in common questions.

Also small changes to index.html language