### PR TITLE
Remove Poloniex from Preferred Exchanges

### DIFF
--- a/content/get-siacoin.html
+++ b/content/get-siacoin.html
@@ -15,10 +15,6 @@ title = "title_getsiacoin"
         <p><img src="/assets/bittrex-logo.png" width="200px"></p>
         <p> {{% i18n "getsiacoin_bittrex" %}} </p>
         <p><a class="btn" href="https://bittrex.com/Market/Index?MarketName=BTC-SC" target="_blank">{{% i18n "getsiacoin_btn" %}}</a></p>
-        <h3>Poloniex</h3>
-        <p><img src="/assets/poloniex-logo.png" width="200px"></p>
-        <p> {{% i18n "getsiacoin_poloniex" %}} </p>
-        <p><a class="btn" href="https://www.poloniex.com/exchange#btc_sc" target="_blank">{{% i18n "getsiacoin_btn" %}}</a></p>
         <h3>Shapeshift</h3>
         <p><img src="/assets/shapeshift-logo.png" width="75px"></p>
         <p> {{% i18n "getsiacoin_shapeshift" %}} </p>


### PR DESCRIPTION
Removing Poloniex as a recommended exchange due to high levels of downtime and support issues.